### PR TITLE
Do not show empty braces in tray item if username was not set

### DIFF
--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -439,7 +439,7 @@ namespace KeeTrayTOTP
                             var context = new SprContext(entry, PluginHost.MainWindow.ActiveDatabase, SprCompileFlags.All, false, false);
                             var entryUsername = SprEngine.Compile(entry.Strings.ReadSafe(PwDefs.UserNameField), context);
                             string trayTitle;
-                            if (trimTrayText && entryTitle.Length + entryUsername.Length > setstat_trim_text_length)
+                            if ((trimTrayText && entryTitle.Length + entryUsername.Length > setstat_trim_text_length) || (string.IsNullOrEmpty(entryUsername)))
                             {
                                 trayTitle = entryTitle.ExtWithSpaceAfter();
                             }


### PR DESCRIPTION
Hi,

The idea of this change is to not show empty braces on a tray menu item if the item doesn't have username assigned to it, just title